### PR TITLE
updated deprecated obspy read/write calls

### DIFF
--- a/seisflows/preprocess/base.py
+++ b/seisflows/preprocess/base.py
@@ -94,14 +94,14 @@ class base(object):
           adjoint traces
         """
         for channel in self.channels:
-            obs = self.reader(path+'/'+'traces/obs/', channel)
-            syn = self.reader(path+'/'+'traces/syn/', channel)
+            obs = self.reader(path+'/'+'traces/obs', channel)
+            syn = self.reader(path+'/'+'traces/syn', channel)
 
             obs = self.process_traces(obs)
             syn = self.process_traces(syn)
 
             self.write_residuals(path, syn, obs)
-            self.write_adjoint_traces(path+'/'+'traces/adj/', syn, obs, channel)
+            self.write_adjoint_traces(path+'/'+'traces/adj', syn, obs, channel)
 
 
     def process_traces(self, stream):
@@ -223,7 +223,7 @@ class base(object):
         dt = PAR.DT
         nt = PAR.NT
         t0 = 0.
-        return dt, nt, t0
+        return nt, dt, t0
 
 
     def get_network_size(self, stream):

--- a/seisflows/seistools/readers.py
+++ b/seisflows/seistools/readers.py
@@ -66,7 +66,7 @@ def ascii_specfem2d(**kwargs):
 
 
 def su_specfem2d_obspy(prefix='SEM', channel=None, suffix='.su'):
-    import obspy
+    from obspy import read
 
     if channel in ['x']:
         filename = '%s/Ux_file_single%s' % (prefix, suffix)
@@ -79,7 +79,7 @@ def su_specfem2d_obspy(prefix='SEM', channel=None, suffix='.su'):
     else:
         raise ValueError('CHANNEL must be one of the following: x y z p')
 
-    streamobj = obspy.segy.core.readSU(filename, byteorder='<')
+    streamobj = read(filename, format='SU')
     return streamobj
 
 
@@ -204,7 +204,7 @@ def su_specfem3d(prefix='SEM', channel=None, suffix='', verbose=False):
 def su_specfem3d_obspy(prefix='SEM', channel=None, suffix='', byteorder='<', verbose=False):
     """ Reads Seismic Unix file
     """
-    from obspy.segy.core import readSU
+    from obspy import read
 
     if channel in ['x']:
         wildcard = '%s/*_dx_SU%s' % (prefix, suffix)
@@ -222,9 +222,9 @@ def su_specfem3d_obspy(prefix='SEM', channel=None, suffix='', byteorder='<', ver
     sort_by = lambda x: int(unix.basename(x).split('_')[0])
     filenames = sorted(filenamess, key=sort_by)
 
-    streamobj = readSU(filenames.pop(), byteorder=byteorder)
+    streamobj = read(filenames.pop(), format='SU')
     for filename in filenames:
-        streamobj += readSU(filename, byteorder=byteorder)
+        streamobj += read(filename, format='SU')
 
     return streamobj
 

--- a/seisflows/seistools/writers.py
+++ b/seisflows/seistools/writers.py
@@ -88,8 +88,7 @@ def su_specfem2d_obspy(d, prefix='SEM', channel=None, suffix='.su.adj'):
             t.stats.delta = dummy_delta
 
     # write data to file
-    from obspy.segy.core import writeSU
-    writeSU(d, file)
+    d.write(file, format='SU')
 
 
 


### PR DESCRIPTION
Future Obspy releases will remove obspy.segy.core. Dropped '/', duplicated in reader/writer routines. 