### PR TITLE
Added MPI system class

### DIFF
--- a/seisflows/seistools/readers.py
+++ b/seisflows/seistools/readers.py
@@ -222,9 +222,9 @@ def su_specfem3d_obspy(prefix='SEM', channel=None, suffix='', byteorder='<', ver
     sort_by = lambda x: int(unix.basename(x).split('_')[0])
     filenames = sorted(filenamess, key=sort_by)
 
-    streamobj = read(filenames.pop(), format='SU')
+    streamobj = read(filenames.pop(), format='SU', byteorder='<')
     for filename in filenames:
-        streamobj += read(filename, format='SU')
+        streamobj += read(filename, format='SU', byteorder='<')
 
     return streamobj
 

--- a/seisflows/system/mpi.py
+++ b/seisflows/system/mpi.py
@@ -1,0 +1,113 @@
+
+import os
+from os.path import abspath, join
+
+import numpy as np
+
+from seisflows.tools import unix
+from seisflows.tools.code import saveobj
+from seisflows.tools.config import SeisflowsParameters, SeisflowsPaths, \
+    ParameterError, loadclass, findpath
+
+PAR = SeisflowsParameters()
+PATH = SeisflowsPaths()
+
+
+class mpi(loadclass('system', 'base')):
+    """ An interface through which to submit workflows, run tasks in serial or 
+      parallel, and perform other system functions.
+
+      By hiding environment details behind a python interface layer, these 
+      classes provide a consistent command set across different computing
+      environments.
+
+      For more informations, see 
+      http://seisflows.readthedocs.org/en/latest/manual/manual.html#system-interfaces
+    """
+
+    def check(self):
+        """ Checks parameters and paths
+        """
+
+        if 'TITLE' not in PAR:
+            setattr(PAR, 'TITLE', unix.basename(abspath('..')))
+
+        if 'NTASK' not in PAR:
+            setattr(PAR, 'NTASK', 1)
+
+        if 'NPROC' not in PAR:
+            setattr(PAR, 'NPROC', 1)
+
+        if 'VERBOSE' not in PAR:
+            setattr(PAR, 'VERBOSE', 1)
+
+        # check paths
+        if 'SCRATCH' not in PATH:
+            setattr(PATH, 'SCRATCH', join(abspath('.'), 'scratch'))
+
+        if 'LOCAL' not in PATH:
+            setattr(PATH, 'LOCAL', '')
+
+        if 'SUBMIT' not in PATH:
+            setattr(PATH, 'SUBMIT', unix.pwd())
+
+        if 'OUTPUT' not in PATH:
+            setattr(PATH, 'OUTPUT', join(PATH.SUBMIT, 'output'))
+
+        if 'SYSTEM' not in PATH:
+            setattr(PATH, 'SYSTEM', join(PATH.SCRATCH, 'system'))
+
+
+    def submit(self, workflow):
+        """ Submits job
+        """
+        unix.mkdir(PATH.OUTPUT)
+        unix.cd(PATH.OUTPUT)
+
+        self.checkpoint()
+        workflow.main()
+
+
+    def run(self, classname, funcname, hosts='all', **kwargs):
+        """ Runs tasks in serial or parallel on specified hosts
+        """
+
+        self.checkpoint()
+        self.save_kwargs(classname, funcname, kwargs)
+
+        if hosts == 'all':
+            unix.cd(join(findpath('system'), 'wrappers'))
+            unix.run('mpiexec -n {} '.format(PAR.NTASK)
+                    + '--mca mpi_warn_on_fork 0' + ' '
+                    + 'run_mpi' + ' '
+                    + PATH.OUTPUT + ' '
+                    + classname + ' '
+                    + funcname)
+
+        elif hosts == 'head':
+            unix.cd(join(findpath('system'), 'wrappers'))
+            unix.run('mpiexec -n 1 '
+                    + '--mca mpi_warn_on_fork 0' + ' '
+                    + 'run_mpi_head' + ' '
+                    + PATH.OUTPUT + ' '
+                    + classname + ' '
+                    + funcname)
+
+        else:
+            raise(KeyError('Hosts parameter not set/recognized'))
+
+    def getnode(self):
+        """Gets number of running task"""
+        return int(os.environ['OMPI_COMM_WORLD_RANK'])
+
+    def mpiargs(self):
+        """ Wrapper for mpiexec
+        """
+        return ''
+
+    def save_kwargs(self, classname, funcname, kwargs):
+        kwargspath = join(PATH.OUTPUT, 'SeisflowsObjects', classname+'_kwargs')
+        kwargsfile = join(kwargspath, funcname+'.p')
+        unix.mkdir(kwargspath)
+        saveobj(kwargsfile, kwargs)
+

--- a/seisflows/system/wrappers/run_mpi
+++ b/seisflows/system/wrappers/run_mpi
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+if __name__ == '__main__':
+    import sys
+    from mpi4py import MPI
+
+    # parse command line arguments
+    mypath = sys.argv[1]
+    myobj = sys.argv[2]
+    myfunc = sys.argv[3]
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+
+    from os.path import join
+    from seisflows.tools.code import loadjson, loadobj
+    from seisflows.tools.config import SeisflowsObjects, SeisflowsParameters, SeisflowsPaths
+
+    # reload from last checkpoint
+    for obj in [SeisflowsParameters(), SeisflowsPaths(), SeisflowsObjects()]:
+       obj.reload(mypath)
+
+    # load function arguments
+    kwargspath = join(mypath, 'SeisflowsObjects', myobj + '_kwargs')
+    kwargs = loadobj(join(kwargspath, myfunc + '.p'))
+
+    # call function
+    func = getattr(sys.modules[myobj], myfunc)
+    func(**kwargs)
+

--- a/seisflows/system/wrappers/run_mpi_head
+++ b/seisflows/system/wrappers/run_mpi_head
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+if __name__ == '__main__':
+    import sys
+    from mpi4py import MPI
+
+    # parse command line arguments
+    mypath = sys.argv[1]
+    myobj = sys.argv[2]
+    myfunc = sys.argv[3]
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+
+    from os.path import join
+    from seisflows.tools.code import loadjson, loadobj
+    from seisflows.tools.config import SeisflowsObjects, SeisflowsParameters, SeisflowsPaths
+
+    # reload from last checkpoint
+    for obj in [SeisflowsParameters(), SeisflowsPaths(), SeisflowsObjects()]:
+       obj.reload(mypath)
+
+    import system
+
+    if system.getnode() == 0:
+        # load function arguments
+        kwargspath = join(mypath, 'SeisflowsObjects', myobj + '_kwargs')
+        kwargs = loadobj(join(kwargspath, myfunc + '.p'))
+
+        # call function
+        func = getattr(sys.modules[myobj], myfunc)
+        func(**kwargs)
+


### PR DESCRIPTION
Adds an MPI system class for task parallelism using mpi4py. Designed to be used with serial/non-mpi solvers and can be readily transported between regular machines and cluster environments. Submit function could be adjusted to resemble cluster qsub/sbatch commands if necessary. Has shown to be more stable than pbsdsh thus far. 

Open-MPI warns about calling calling fork(), system(), or popen() in MPI processes but assuming the workflow is designed correctly (i.e. function calls are to independent events/cause no conflicts, this should be safe. 